### PR TITLE
Make flake8 happy

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length=88


### PR DESCRIPTION
Flake8 tries to enforce a line length of 79 chars, but black formats the code to have 88 chars.